### PR TITLE
fix: pin @stacks dependencies to last working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g @stacks/send-many-stx-cli
 $ stx-bulk-transfer COMMAND
 running command...
 $ stx-bulk-transfer (-v|--version|version)
-@stacks/send-many-stx-cli/1.1.0 darwin-x64 node-v14.15.4
+@stacks/send-many-stx-cli/1.1.1 darwin-x64 node-v14.15.4
 $ stx-bulk-transfer --help [COMMAND]
 USAGE
   $ stx-bulk-transfer COMMAND

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stacks/send-many-stx-cli",
   "description": "A simple CLI for making a bulk STX transfer in one command.",
   "author": "Hiro PBC",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -74,7 +74,9 @@
   },
   "dependencies": {
     "@oclif/command": "^1.8.0",
-    "@stacks/transactions": "^1.0.1",
+    "@stacks/common": "1.2.2",
+    "@stacks/network": "1.2.2",
+    "@stacks/transactions": "1.2.2",
     "bn.js": "^5.1.3",
     "c32check": "^1.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,27 +1314,27 @@
     webpack "^4.44.1"
     webpack-bundle-analyzer "^3.9.0"
 
-"@stacks/common@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-1.0.1.tgz#76fea117e38a6a4b901242513bb765a485104f47"
-  integrity sha512-Rw+ezdoJ/5kc8MklAUerOusVHzn3FOibVqq8+iyTa4FGSd0CiDoByCEBQQ9+T6GsxgVVOTL/e+YCwWL/Ywu2UQ==
+"@stacks/common@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@stacks/common/-/common-1.2.2.tgz#1365ffb0f8bd9e4cd194c63c65a1bb2c83876ba1"
+  integrity sha512-knCqq88EBRCN8AhS7+Sx2PJuRv0EFNChEpqLqCAchCHCQfp5bWad/47Zw+fLP9ccBwFXh4pl1wDtbQLBfDo0+A==
   dependencies:
     cross-fetch "^3.0.6"
 
-"@stacks/network@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-1.0.1.tgz#f70b18d7912aed3dd48396737c633f4dbcb59d4d"
-  integrity sha512-rhPIB4Jd9FzUzVvQtnfGQBRAp+c6IfmDr/cSg+MKp7SD9tvquJKGoiiTguzpT7/ZVpUR12LFAveTWZec6bqXaw==
+"@stacks/network@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@stacks/network/-/network-1.2.2.tgz#30ca87ad6339f32eb04ed3a9dbcc2e39ed933604"
+  integrity sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==
   dependencies:
-    "@stacks/common" "^1.0.1"
+    "@stacks/common" "1.2.2"
 
-"@stacks/transactions@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-1.0.1.tgz#97989dde899b0dbca48c3bb165889656f05f0a08"
-  integrity sha512-q5APFxDNeleqTBS2dNl6s0VO/f2d77yklN5P5yKA9nJ4EoYpZvoVl/RTeHnz5NQaD7yTvmcjQaebdZAveppSVQ==
+"@stacks/transactions@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-1.2.2.tgz#b5d8eca6d12c92454f296aa436fea1906efeac53"
+  integrity sha512-V/2PNtePtCrJqm32J7LUm6G+Bj4tXgWwGt1obYHJZwHmHztUCz3v2ogtiw+3tX2qT/QTw37PX8hJnt1Pn4LUaw==
   dependencies:
-    "@stacks/common" "^1.0.1"
-    "@stacks/network" "^1.0.1"
+    "@stacks/common" "1.2.2"
+    "@stacks/network" "1.2.2"
     "@types/bn.js" "^4.11.6"
     "@types/elliptic" "^6.4.12"
     "@types/randombytes" "^2.0.0"
@@ -1344,6 +1344,7 @@
     cross-fetch "^3.0.5"
     elliptic "^6.5.3"
     lodash "^4.17.20"
+    lodash-es "4.17.20"
     randombytes "^2.1.0"
     ripemd160-min "^0.0.6"
     sha.js "^2.4.11"
@@ -6797,6 +6798,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
+  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A recent version of the `@stacks` libs caused this lib to break with:

```
➜ stx-bulk-transfer
node:internal/modules/cjs/loader:926
  throw err;
  ^

Error: Cannot find module './transactions.cjs.development.js'
Require stack:
- /usr/local/lib/node_modules/@stacks/send-many-stx-cli/node_modules/@stacks/transactions/dist/index.js
- /usr/local/lib/node_modules/@stacks/send-many-stx-cli/dist/builder.js
- /usr/local/lib/node_modules/@stacks/send-many-stx-cli/dist/commands/send-many.js
- /usr/local/lib/node_modules/@stacks/send-many-stx-cli/dist/index.js
- /usr/local/lib/node_modules/@stacks/send-many-stx-cli/bin/run
```

Pinning the dependencies to the last working version fixes the issue. 