### PR TITLE
fix: deploy new testnet contracts #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ DESCRIPTION
 
      The default contracts can be found below:
 
-     Testnet: https://explorer.stacks.co/txid/STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many?chain=testnet
+     Testnet: https://explorer.stacks.co/txid/ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many?chain=testnet
      Mainnet: https://explorer.stacks.co/txid/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many?chain=mainnet
 
      Example usage:
@@ -188,7 +188,7 @@ DESCRIPTION
 
      The default contracts can be found below:
 
-     Testnet: https://explorer.stacks.co/txid/STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many-memo?chain=testnet
+     Testnet: https://explorer.stacks.co/txid/ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo?chain=testnet
      Mainnet: https://explorer.stacks.co/txid/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo?chain=mainnet
 
      Example usage:
@@ -252,7 +252,7 @@ DESCRIPTION
 
      The default contracts can be found below:
 
-     Testnet: https://explorer.stacks.co/txid/STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many-memo?chain=testnet
+     Testnet: https://explorer.stacks.co/txid/ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo?chain=testnet
      Mainnet: https://explorer.stacks.co/txid/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo?chain=mainnet
 
      Example usage:

--- a/src/commands/deploy-contract.ts
+++ b/src/commands/deploy-contract.ts
@@ -4,9 +4,11 @@ import { StacksMocknet, StacksMainnet, StacksTestnet } from '@stacks/network';
 import {
   broadcastTransaction,
   ChainID,
+  ContractDeployOptions,
   makeContractDeploy,
 } from '@stacks/transactions';
 import { promises as fs } from 'fs';
+import BN from 'bn.js';
 
 type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
 type Contract = 'send-many' | 'send-many-memo' | 'memo-expected';
@@ -121,12 +123,16 @@ only the raw transaction hex will be logged.
       network.coreApiUrl = flags.nodeUrl;
     }
 
-    const tx = await makeContractDeploy({
+    const txOptions: ContractDeployOptions = {
       contractName: contract,
       codeBody: await this.getContractCode(contract),
       senderKey: flags.privateKey,
       network,
-    });
+    };
+    if (flags.nonce !== undefined) {
+      txOptions.nonce = new BN(flags.nonce);
+    }
+    const tx = await makeContractDeploy(txOptions);
 
     const verbose = !flags.quiet;
 

--- a/src/commands/send-many-memo-safe.ts
+++ b/src/commands/send-many-memo-safe.ts
@@ -17,7 +17,7 @@ import fetch, { Response } from 'node-fetch';
 type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
 
 const DEFAULT_TESTNET_CONTRACT =
-  'STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many-memo';
+  'ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo';
 const DEFAULT_MAINNET_CONTRACT =
   'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo';
 

--- a/src/commands/send-many-memo.ts
+++ b/src/commands/send-many-memo.ts
@@ -16,7 +16,7 @@ import { STXPostCondition } from '@stacks/transactions/dist/transactions/src/pos
 type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
 
 const DEFAULT_TESTNET_CONTRACT =
-  'STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many-memo';
+  'ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo';
 const DEFAULT_MAINNET_CONTRACT =
   'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo';
 

--- a/src/commands/send-many.ts
+++ b/src/commands/send-many.ts
@@ -16,7 +16,7 @@ import { STXPostCondition } from '@stacks/transactions/dist/transactions/src/pos
 type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
 
 const DEFAULT_TESTNET_CONTRACT =
-  'STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many';
+  'ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many';
 const DEFAULT_MAINNET_CONTRACT =
   'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many';
 


### PR DESCRIPTION
Fix #4 by deploying the send-many contracts to testnet and updating the contract addresses used.

Also fixed a bug with `nonce` arg being ignored in the deploy-contract command. 