### PR TITLE
feat: allow stx-transfer tx type for single recipients #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g @stacks/send-many-stx-cli
 $ stx-bulk-transfer COMMAND
 running command...
 $ stx-bulk-transfer (-v|--version|version)
-@stacks/send-many-stx-cli/1.3.0 darwin-x64 node-v14.17.5
+@stacks/send-many-stx-cli/1.4.0 darwin-x64 node-v16.11.1
 $ stx-bulk-transfer --help [COMMAND]
 USAGE
   $ stx-bulk-transfer COMMAND
@@ -83,6 +83,8 @@ DESCRIPTION
      ```
 ```
 
+_See code: [dist/commands/deploy-contract.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/deploy-contract.ts)_
+
 ## `stx-bulk-transfer send-many [RECIPIENTS]`
 
 Execute a bulk STX transfer.
@@ -96,6 +98,10 @@ ARGUMENTS
               Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100 ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH,50
 
 OPTIONS
+  -a, --allowSingleStxTransfer           If enabled and only a single recipient is specified, a STX-transfer transaction
+                                         type will be used rather than a contract-call transaction.
+                                         If omitted, a contract-call will always be used, which can be less efficient.
+
   -b, --broadcast                        Whether to broadcast this transaction. Omitting this flag will not broadcast
                                          the transaction.
 
@@ -140,6 +146,8 @@ DESCRIPTION
      ```
 ```
 
+_See code: [dist/commands/send-many.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/send-many.ts)_
+
 ## `stx-bulk-transfer send-many-memo [RECIPIENTS]`
 
 Execute a bulk STX transfer, with memos attached.
@@ -153,6 +161,10 @@ ARGUMENTS
               Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH,50
 
 OPTIONS
+  -a, --allowSingleStxTransfer           If enabled and only a single recipient is specified, a STX-transfer transaction
+                                         type will be used rather than a contract-call transaction.
+                                         If omitted, a contract-call will always be used, which can be less efficient.
+
   -b, --broadcast                        Whether to broadcast this transaction. Omitting this flag will not broadcast
                                          the transaction.
 
@@ -199,6 +211,8 @@ DESCRIPTION
      ```
 ```
 
+_See code: [dist/commands/send-many-memo.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/send-many-memo.ts)_
+
 ## `stx-bulk-transfer send-many-memo-safe [RECIPIENTS]`
 
 Execute a bulk STX transfer, with memos attached, checking if the transfer is safe to send.
@@ -212,6 +226,10 @@ ARGUMENTS
               Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH,50
 
 OPTIONS
+  -a, --allowSingleStxTransfer           If enabled and only a single recipient is specified, a STX-transfer transaction
+                                         type will be used rather than a contract-call transaction.
+                                         If omitted, a contract-call will always be used, which can be less efficient.
+
   -b, --broadcast                        Whether to broadcast this transaction. Omitting this flag will not broadcast
                                          the transaction.
 
@@ -262,6 +280,8 @@ DESCRIPTION
   ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH,50,memo2 -k my_private_key -n testnet -b
      ```
 ```
+
+_See code: [dist/commands/send-many-memo-safe.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/send-many-memo-safe.ts)_
 <!-- commandsstop -->
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "@stacks/send-many-stx-cli",
   "description": "A simple CLI for making a bulk STX transfer in one command.",
   "author": "Hiro PBC",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
+  "homepage": "https://github.com/blockstack/send-many-stx-cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blockstack/send-many-stx-cli.git"
+  },
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/commands/send-many-memo.ts
+++ b/src/commands/send-many-memo.ts
@@ -1,5 +1,11 @@
 import { Command, flags } from '@oclif/command';
-import { sendMany, Recipient, isNormalInteger, getAddress } from '../builder';
+import {
+  sendMany,
+  Recipient,
+  isNormalInteger,
+  getAddress,
+  sendStxTransfer,
+} from '../builder';
 import {
   StacksMocknet,
   StacksMainnet,
@@ -9,6 +15,7 @@ import {
 import {
   broadcastTransaction,
   ChainID,
+  StacksTransaction,
   validateStacksAddress,
 } from '@stacks/transactions';
 import { STXPostCondition } from '@stacks/transactions/dist/transactions/src/postcondition';
@@ -93,6 +100,15 @@ Optionally specify a fee multiplier. If passed, the tx fee will be (estimated fe
 For example, a fee multiplier of 15 for a tx with an estimated fee of 200 would result in a tx with the fee of 230.
 `,
     }),
+    allowSingleStxTransfer: flags.boolean({
+      required: false,
+      char: 'a',
+      default: false,
+      description: `
+If enabled and only a single recipient is specified, a STX-transfer transaction type will be used rather than a contract-call transaction. 
+If omitted, a contract-call will always be used, which can be less efficient.
+`,
+    }),
   };
 
   static args = [
@@ -155,15 +171,29 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
     const contractIdentifier =
       flags.contractAddress || this.getContract(network);
 
-    const tx = await sendMany({
-      recipients,
-      network,
-      senderKey: flags.privateKey,
-      contractIdentifier,
-      nonce: flags.nonce,
-      feeMultiplier: flags.feeMultiplier,
-      withMemo: true,
-    });
+    let tx: StacksTransaction;
+    const performStxTransferTx: boolean =
+      recipients.length === 1 && flags.allowSingleStxTransfer;
+    if (performStxTransferTx) {
+      tx = await sendStxTransfer({
+        recipient: recipients[0],
+        network,
+        senderKey: flags.privateKey,
+        nonce: flags.nonce,
+        feeMultiplier: flags.feeMultiplier,
+        withMemo: true,
+      });
+    } else {
+      tx = await sendMany({
+        recipients,
+        network,
+        senderKey: flags.privateKey,
+        contractIdentifier,
+        nonce: flags.nonce,
+        feeMultiplier: flags.feeMultiplier,
+        withMemo: true,
+      });
+    }
 
     const verbose = !flags.quiet;
 
@@ -186,6 +216,10 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
         .values as STXPostCondition[])[0].amount.toString(),
       transactionHex: tx.serialize().toString('hex'),
     };
+
+    if (flags.allowSingleStxTransfer) {
+      outputEntries.isStxTransferTxType = performStxTransferTx;
+    }
 
     let broadcastFailed = false;
     if (flags.broadcast) {

--- a/src/commands/send-many.ts
+++ b/src/commands/send-many.ts
@@ -1,5 +1,11 @@
 import { Command, flags } from '@oclif/command';
-import { sendMany, Recipient, isNormalInteger, getAddress } from '../builder';
+import {
+  sendMany,
+  Recipient,
+  isNormalInteger,
+  getAddress,
+  sendStxTransfer,
+} from '../builder';
 import {
   StacksMocknet,
   StacksMainnet,
@@ -9,6 +15,7 @@ import {
 import {
   broadcastTransaction,
   ChainID,
+  StacksTransaction,
   validateStacksAddress,
 } from '@stacks/transactions';
 import { STXPostCondition } from '@stacks/transactions/dist/transactions/src/postcondition';
@@ -88,6 +95,15 @@ Optionally specify a fee multiplier. If passed, the tx fee will be (estimated fe
 For example, a fee multiplier of 15 for a tx with an estimated fee of 200 would result in a tx with the fee of 230.
 `,
     }),
+    allowSingleStxTransfer: flags.boolean({
+      required: false,
+      char: 'a',
+      default: false,
+      description: `
+If enabled and only a single recipient is specified, a STX-transfer transaction type will be used rather than a contract-call transaction. 
+If omitted, a contract-call will always be used, which can be less efficient.
+`,
+    }),
   };
 
   static args = [
@@ -149,14 +165,27 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100 ST2WPFYAW85A0YK9ACJR8JGWPM
     const contractIdentifier =
       flags.contractAddress || this.getContract(network);
 
-    const tx = await sendMany({
-      recipients,
-      network,
-      senderKey: flags.privateKey,
-      contractIdentifier,
-      nonce: flags.nonce,
-      feeMultiplier: flags.feeMultiplier,
-    });
+    let tx: StacksTransaction;
+    const performStxTransferTx: boolean =
+      recipients.length === 1 && flags.allowSingleStxTransfer;
+    if (performStxTransferTx) {
+      tx = await sendStxTransfer({
+        recipient: recipients[0],
+        network,
+        senderKey: flags.privateKey,
+        nonce: flags.nonce,
+        feeMultiplier: flags.feeMultiplier,
+      });
+    } else {
+      tx = await sendMany({
+        recipients,
+        network,
+        senderKey: flags.privateKey,
+        contractIdentifier,
+        nonce: flags.nonce,
+        feeMultiplier: flags.feeMultiplier,
+      });
+    }
 
     const verbose = !flags.quiet;
 
@@ -168,6 +197,9 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100 ST2WPFYAW85A0YK9ACJR8JGWPM
       this.log('Sender:', getAddress(flags.privateKey, network));
       const [postCondition] = tx.postConditions.values as STXPostCondition[];
       this.log('Total amount:', postCondition.amount.toNumber());
+      if (flags.allowSingleStxTransfer) {
+        this.log('Is STX-transfer transaction type: ', performStxTransferTx);
+      }
     }
 
     if (flags.broadcast) {


### PR DESCRIPTION
Closes https://github.com/blockstack/send-many-stx-cli/issues/9

Adds a new option:
```
  -a, --allowSingleStxTransfer           If enabled and only a single recipient is specified, a STX-transfer transaction
                                         type will be used rather than a contract-call transaction.
                                         If omitted, a contract-call will always be used, which can be less efficient.
```

This is a backwards compatible, opt-in feature. 

If the new flag is specified, and if only a single recipient is provided, then a STX transfer tx is created rather than a contract-call.

## Examples
Single recipient provided, but the new flag is omitted (no change, a contract-call tx is created):
```
$ send-many-memo STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,12,hello -k <key> -n testnet
recipients:
  address: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW
  amount: 12
  memo: hello
  ----------
fee: 270
nonce: 7
contract: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo
sender: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B
totalAmount: 12
transactionHex: 80800000000400de1e92f0d8b34475a937485a1b1abf66a0dbf2ff0000000000000007000000000000010e0000f45f0f37eccfbc23b2025493b02858f3de2db6e4132ee693cc902c25fb636e695591460c51510dfb592faa8d3ed060caf7325cd7a9ea78143dc48cb5d185212e03020000000100021ade1e92f0d8b34475a937485a1b1abf66a0dbf2ff01000000000000000c021ade1e92f0d8b34475a937485a1b1abf66a0dbf2ff0e73656e642d6d616e792d6d656d6f0973656e642d6d616e79000000010b000000010c00000003046d656d6f020000000568656c6c6f02746f051a14da62c539f2c1d195b1f43b633afae472be454c0475737478010000000000000000000000000000000c
```

Single recipient provided, but the `--allowSingleStxTransfer` flag is specified (a stx-transfer tx is created):
```
$ send-many-memo STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,12,hello -k <key> -n testnet -a
recipients:
  address: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW
  amount: 12
  memo: hello
  ----------
fee: 212
nonce: 7
contract: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo
sender: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B
totalAmount: 12
transactionHex: 80800000000400de1e92f0d8b34475a937485a1b1abf66a0dbf2ff000000000000000700000000000000d40000c776e7998ebd01e84a6763d0264130af7843142c81dac6efda52a85bd1ad1e7c7b94ac4ae5d9a209fa9080969fa407ef3f2cccbdc131ceaa18d78699eb0bbd3c03020000000100021ade1e92f0d8b34475a937485a1b1abf66a0dbf2ff01000000000000000c00051a14da62c539f2c1d195b1f43b633afae472be454c000000000000000c68656c6c6f0000000000000000000000000000000000000000000000000000000000
isStxTransferTxType: true
```

Multiple recipients provided, the `--allowSingleStxTransfer` flag is specified (no change, a contract-call tx is created):
```
$ send-many-memo-safe STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,12,hello ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH,50,memo2 -k <key> -n testnet -a
recipients:
  address: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW
  amount: 12
  memo: hello
  ----------
  address: ST2WPFYAW85A0YK9ACJR8JGWPM19VWYF90J8P5ZTH
  amount: 50
  memo: memo2
  ----------
fee: 337
nonce: 7
contract: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B.send-many-memo
sender: ST3F1X4QGV2SM8XD96X45M6RTQXKA1PZJZZCQAB4B
totalAmount: 62
transactionHex: 80800000000400de1e92f0d8b34475a937485a1b1abf66a0dbf2ff0000000000000007000000000000015100009b14d291682ea1339a511543b1ecbaaa499198b2232500fd209b1e997a1ecf8456900ac15d1d44c4ae4778cace4113ea0a651562d81255681d333ab4ee7af6d103020000000100021ade1e92f0d8b34475a937485a1b1abf66a0dbf2ff01000000000000003e021ade1e92f0d8b34475a937485a1b1abf66a0dbf2ff0e73656e642d6d616e792d6d656d6f0973656e642d6d616e79000000010b000000020c00000003046d656d6f020000000568656c6c6f02746f051a14da62c539f2c1d195b1f43b633afae472be454c0475737478010000000000000000000000000000000c0c00000003046d656d6f02000000056d656d6f3202746f051ab967f95c41540f4d2a64b0894396a053be79e90404757374780100000000000000000000000000000032
isStxTransferTxType: false
```