### PR TITLE
feat: validate-address command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g @stacks/send-many-stx-cli
 $ stx-bulk-transfer COMMAND
 running command...
 $ stx-bulk-transfer (-v|--version|version)
-@stacks/send-many-stx-cli/1.4.0 darwin-x64 node-v16.11.1
+@stacks/send-many-stx-cli/1.4.0 darwin-arm64 node-v15.14.0
 $ stx-bulk-transfer --help [COMMAND]
 USAGE
   $ stx-bulk-transfer COMMAND
@@ -33,6 +33,7 @@ USAGE
 * [`stx-bulk-transfer send-many [RECIPIENTS]`](#stx-bulk-transfer-send-many-recipients)
 * [`stx-bulk-transfer send-many-memo [RECIPIENTS]`](#stx-bulk-transfer-send-many-memo-recipients)
 * [`stx-bulk-transfer send-many-memo-safe [RECIPIENTS]`](#stx-bulk-transfer-send-many-memo-safe-recipients)
+* [`stx-bulk-transfer validate-address [ADDRESS]`](#stx-bulk-transfer-validate-address-address)
 
 ## `stx-bulk-transfer deploy-contract [CONTRACT]`
 
@@ -282,6 +283,32 @@ DESCRIPTION
 ```
 
 _See code: [dist/commands/send-many-memo-safe.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/send-many-memo-safe.ts)_
+
+## `stx-bulk-transfer validate-address [ADDRESS]`
+
+Validates whether the input is a valid STX address for the provided network.
+
+```
+USAGE
+  $ stx-bulk-transfer validate-address [ADDRESS]
+
+ARGUMENTS
+  ADDRESS  The address to validate
+
+OPTIONS
+  -h, --help                             show CLI help
+  -n, --network=mocknet|testnet|mainnet  [default: mainnet] Which network to check for
+  -v, --verbose                          Print error information for invalid addresses
+
+DESCRIPTION
+  Example usage:
+
+     ```
+     npx stx-bulk-transfer validate-address SP000000000000000000002Q6VF78 -n mainnet
+     ```
+```
+
+_See code: [dist/commands/validate-address.ts](https://github.com/blockstack/send-many-stx-cli/blob/v1.4.0/dist/commands/validate-address.ts)_
 <!-- commandsstop -->
 
 ## Development

--- a/src/commands/validate-address.ts
+++ b/src/commands/validate-address.ts
@@ -1,0 +1,84 @@
+import { Command, flags } from '@oclif/command';
+import { c32addressDecode, versions as NetworkVersions } from 'c32check';
+
+type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
+
+export class ValidateAddress extends Command {
+	static description = `Validates whether the input is a valid STX address for the provided network.
+
+  Example usage:
+
+  \`\`\`
+  npx stx-bulk-transfer validate-address SP000000000000000000002Q6VF78 -n mainnet
+  \`\`\`
+  `;
+	static strict = true;
+
+	static flags = {
+		help: flags.help({ char: 'h' }),
+		network: flags.string({
+			char: 'n',
+			description: 'Which network to check for',
+			options: ['mocknet', 'testnet', 'mainnet'],
+			default: 'mainnet',
+		}),
+		verbose: flags.boolean({
+			required: false,
+			char: 'v',
+			default: false,
+			description: 'Print error information for invalid addresses',
+		})
+	};
+
+	static args = [
+		{
+			name: 'address',
+			description: `The address to validate`,
+		},
+	];
+
+	getNetworkVersion() {
+		const { flags } = this.parse(ValidateAddress);
+
+		const networks = {
+			mainnet: NetworkVersions.mainnet,
+			testnet: NetworkVersions.testnet,
+			mocknet: NetworkVersions.testnet,
+		};
+
+		return networks[flags.network as NetworkString];
+	}
+
+	async run() {
+		const { argv, flags } = this.parse(ValidateAddress);
+		const [address] = argv;
+
+		if (!address) {
+			throw new Error('No address specified, try --help');
+		}
+
+		const networkVersion = this.getNetworkVersion();
+		if (!networkVersion) {
+			throw new Error('Invalid network');
+		}
+
+		try {
+			const [version] = c32addressDecode(address);
+			if (version === networkVersion.p2pkh || version === networkVersion.p2sh) {
+				this.log('1');
+			}
+			else {
+				this.log('0');
+				if (flags.verbose) {
+					this.log(`Valid address but incorrect network version (address version: ${version}, expected: ${networkVersion.p2pkh} or ${networkVersion.p2sh})`);
+				}
+			}
+		}
+		catch (error) {
+			this.log('0');
+			if (flags.verbose) {
+				this.log(error as any);
+			}
+		}
+	}
+}

--- a/src/commands/validate-address.ts
+++ b/src/commands/validate-address.ts
@@ -69,6 +69,7 @@ export class ValidateAddress extends Command {
 			}
 			else {
 				this.log('0');
+				process.exitCode = 1; // Exit code 1 means valid address but incorrect network version.
 				if (flags.verbose) {
 					this.log(`Valid address but incorrect network version (address version: ${version}, expected: ${networkVersion.p2pkh} or ${networkVersion.p2sh})`);
 				}
@@ -76,6 +77,7 @@ export class ValidateAddress extends Command {
 		}
 		catch (error) {
 			this.log('0');
+			process.exitCode = 2; // Exit code 2 means malformed STX address.
 			if (flags.verbose) {
 				this.log(error as any);
 			}

--- a/src/commands/validate-address.ts
+++ b/src/commands/validate-address.ts
@@ -4,83 +4,83 @@ import { c32addressDecode, versions as NetworkVersions } from 'c32check';
 type NetworkString = 'mocknet' | 'mainnet' | 'testnet';
 
 export class ValidateAddress extends Command {
-	static description = `Validates whether the input is a valid STX address for the provided network.
-
+  static description = `Validates whether the input is a valid STX address for the provided network.
+  
   Example usage:
-
+  
   \`\`\`
   npx stx-bulk-transfer validate-address SP000000000000000000002Q6VF78 -n mainnet
   \`\`\`
   `;
-	static strict = true;
+  static strict = true;
 
-	static flags = {
-		help: flags.help({ char: 'h' }),
-		network: flags.string({
-			char: 'n',
-			description: 'Which network to check for',
-			options: ['mocknet', 'testnet', 'mainnet'],
-			default: 'mainnet',
-		}),
-		verbose: flags.boolean({
-			required: false,
-			char: 'v',
-			default: false,
-			description: 'Print error information for invalid addresses',
-		})
-	};
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    network: flags.string({
+      char: 'n',
+      description: 'Which network to check for',
+      options: ['mocknet', 'testnet', 'mainnet'],
+      default: 'mainnet',
+    }),
+    verbose: flags.boolean({
+      required: false,
+      char: 'v',
+      default: false,
+      description: 'Print error information for invalid addresses',
+    })
+  };
 
-	static args = [
-		{
-			name: 'address',
-			description: `The address to validate`,
-		},
-	];
+  static args = [
+    {
+      name: 'address',
+      description: `The address to validate`,
+    },
+  ];
 
-	getNetworkVersion() {
-		const { flags } = this.parse(ValidateAddress);
+  getNetworkVersion() {
+    const { flags } = this.parse(ValidateAddress);
 
-		const networks = {
-			mainnet: NetworkVersions.mainnet,
-			testnet: NetworkVersions.testnet,
-			mocknet: NetworkVersions.testnet,
-		};
+    const networks = {
+      mainnet: NetworkVersions.mainnet,
+      testnet: NetworkVersions.testnet,
+      mocknet: NetworkVersions.testnet,
+    };
 
-		return networks[flags.network as NetworkString];
-	}
+    return networks[flags.network as NetworkString];
+  }
 
-	async run() {
-		const { argv, flags } = this.parse(ValidateAddress);
-		const [address] = argv;
+  async run() {
+    const { argv, flags } = this.parse(ValidateAddress);
+    const [address] = argv;
 
-		if (!address) {
-			throw new Error('No address specified, try --help');
-		}
+    if (!address) {
+      throw new Error('No address specified, try --help');
+    }
 
-		const networkVersion = this.getNetworkVersion();
-		if (!networkVersion) {
-			throw new Error('Invalid network');
-		}
+    const networkVersion = this.getNetworkVersion();
+    if (!networkVersion) {
+      throw new Error('Invalid network');
+    }
 
-		try {
-			const [version] = c32addressDecode(address);
-			if (version === networkVersion.p2pkh || version === networkVersion.p2sh) {
-				this.log('1');
-			}
-			else {
-				this.log('0');
-				process.exitCode = 1; // Exit code 1 means valid address but incorrect network version.
-				if (flags.verbose) {
-					this.log(`Valid address but incorrect network version (address version: ${version}, expected: ${networkVersion.p2pkh} or ${networkVersion.p2sh})`);
-				}
-			}
-		}
-		catch (error) {
-			this.log('0');
-			process.exitCode = 2; // Exit code 2 means malformed STX address.
-			if (flags.verbose) {
-				this.log(error as any);
-			}
-		}
-	}
+    try {
+      const [version] = c32addressDecode(address);
+      if (version === networkVersion.p2pkh || version === networkVersion.p2sh) {
+        this.log('1');
+      }
+      else {
+        this.log('0');
+        process.exitCode = 1; // Exit code 1 means valid address but incorrect network version.
+        if (flags.verbose) {
+          this.log(`Valid address but incorrect network version (address version: ${version}, expected: ${networkVersion.p2pkh} or ${networkVersion.p2sh})`);
+        }
+      }
+    }
+    catch (error) {
+      this.log('0');
+      process.exitCode = 2; // Exit code 2 means malformed STX address.
+      if (flags.verbose) {
+        this.log(error as any);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds the `validate-address` utility command to check if an address is valid for the specified network. Returns `1` if it is valid or `0` if it is not.

The flag `--verbose` / `-v` can be specified to output an error string on a newline if the result is `0`.

The command also exits with a non-zero exit code if address verification fails.
- `1` means valid address but wrong network version.
- `2` means invalid STX address.

This command is useful for integration partners that leverage the send-many tool for their transfers but cannot use stacks.js in their existing system architecture.

Example usage:

```bash
stx-bulk-transfer validate-address SM1D5WZDAR17J8S4GSYTB8PS9V5WKAZNZA0DZ76BZ -n testnet 
0
stx-bulk-transfer validate-address SM1D5WZDAR17J8S4GSYTB8PS9V5WKAZNZA0DZ76BZ -n mainnet
1
stx-bulk-transfer validate-address SP36XPF3GEP9T8F338VAYQFZR60C10TCXRN52YQHG -n mainnet
1
stx-bulk-transfer validate-address SP36XPF3GEP9T8F338VAYQFZR60C10TCXRN52YQHG -n testnet
0
stx-bulk-transfer validate-address ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5 -n testnet
1
stx-bulk-transfer validate-address ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5 -n mainnet
0
stx-bulk-transfer validate-address ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5 -n mainnet -v
0
Valid address but incorrect network version (address version: 26, expected: 22 or 20)
```